### PR TITLE
emu/log: s/logger/log

### DIFF
--- a/emu/log/terminal_darwin.go
+++ b/emu/log/terminal_darwin.go
@@ -1,4 +1,4 @@
-package logger
+package log
 
 import "syscall"
 

--- a/emu/log/terminal_windows.go
+++ b/emu/log/terminal_windows.go
@@ -1,4 +1,4 @@
-package logger
+package log
 
 func IsTerminal(fd int) bool {
 	return true


### PR DESCRIPTION
Fix `logger` package name, remained `log` on windows and darwin.