### PR TITLE
refactoring of websocket communications

### DIFF
--- a/nestor-dbg/.prettierrc
+++ b/nestor-dbg/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "singleQuote": true,
+    "trailingComma": "none"
+}

--- a/nestor-dbg/package-lock.json
+++ b/nestor-dbg/package-lock.json
@@ -18,7 +18,6 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
-        "react-use-websocket": "^4.8.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
@@ -22894,9 +22893,10 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
-      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
+      "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -23808,15 +23808,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-use-websocket": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-4.8.1.tgz",
-      "integrity": "sha512-FTXuG5O+LFozmu1BRfrzl7UIQngECvGJmL7BHsK4TYXuVt+mCizVA8lT0hGSIF0Z0TedF7bOo1nRzOUdginhDw==",
-      "peerDependencies": {
-        "react": ">= 18.0.0",
-        "react-dom": ">= 18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/nestor-dbg/package.json
+++ b/nestor-dbg/package.json
@@ -13,7 +13,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
-    "react-use-websocket": "^4.8.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },
@@ -23,7 +22,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "pretty": "prettier --write \"./**/*.{js,jsx,mjs,cjs,ts,tsx,json}\""
   },
   "eslintConfig": {
     "extends": [

--- a/nestor-dbg/src/App.tsx
+++ b/nestor-dbg/src/App.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
 import './App.css';
 import Debugger from './components/Debugger';
+import useWS from './ws/hook';
 
 function App() {
+  const [, ready] = useWS();
+
   return (
     <div className="App">
+      {!ready && <div>Connecting...</div>}
       <Debugger />
     </div>
   );

--- a/nestor-dbg/src/components/Debugger.tsx
+++ b/nestor-dbg/src/components/Debugger.tsx
@@ -1,107 +1,74 @@
-import React, { useState, useEffect } from 'react';
-import useWebSocket, { ReadyState } from 'react-use-websocket';
-
-enum CPUState {
-    Running = 'running',
-    Paused = 'paused',
-    Stepping = 'stepping'
-}
-
-export interface NestorData {
-    event: string;
-    data: {};
-}
+import React from 'react';
+import { CPUState } from '../types';
+import useWS from '../ws/hook';
 
 export interface DebuggerState {
-    cpu: CPUState;
+  cpu: CPUState;
 }
-
-interface WebSocketManagerProps {
-    onMessage: (message: NestorData) => void;
-    onStateReceived: (state: DebuggerState) => void;
-}
-
-export const WebSocketManager: React.FC<WebSocketManagerProps> = ({ onMessage, onStateReceived }) => {
-    const WS_URL = 'ws://localhost:7777/ws';
-    const { sendJsonMessage, lastJsonMessage, readyState } = useWebSocket(WS_URL, {
-        share: false,
-        shouldReconnect: () => true,
-    });
-
-    useEffect(() => {
-        console.log('Connection state changed');
-        if (readyState === ReadyState.OPEN) {
-            console.log('WebSocket connection opened');
-        }
-    }, [readyState, sendJsonMessage]);
-
-    useEffect(() => {
-        if (lastJsonMessage) {
-            console.log(`received from nestor: "`, JSON.stringify(lastJsonMessage));
-            const parsedMessage = lastJsonMessage as NestorData;
-            if (parsedMessage.event === 'state') {
-                const state = parsedMessage.data as DebuggerState;
-                onStateReceived(state);
-            }
-            onMessage(parsedMessage);
-        }
-    }, [lastJsonMessage, onMessage, onStateReceived]);
-
-    return null;
-};
-
-
-
 
 // Define ButtonProps interface
 interface ButtonProps {
-    onClick: () => void;
-    disabled: boolean;
-    children: React.ReactNode;
+  onClick: () => void;
+  disabled: boolean;
+  children: React.ReactNode;
 }
 
 // Button component
 const Button: React.FC<ButtonProps> = ({ onClick, disabled, children }) => (
-    <button onClick={onClick} disabled={disabled}>
-        {children}
-    </button>
+  <button onClick={onClick} disabled={disabled}>
+    {children}
+  </button>
 );
 
 // Debugger component
-const Debugger: React.FC = () => {
-    const [message, setMessage] = React.useState<NestorData | null>(null);
-    const [debuggerState, setDebuggerState] = useState<DebuggerState | null>(null);
+function Debugger() {
+  const [debuggerState, setDebuggerState] =
+    React.useState<DebuggerState | null>(null);
 
-    const handleNewMessage = (newMessage: NestorData) => {
-        setMessage(newMessage);
-    };
+  const [ws] = useWS();
 
-    const handleStateReceived = (state: DebuggerState) => {
-        setDebuggerState(state);
-    };
+  React.useEffect(() => {
+    if (!ws) return;
 
-    const handleStart = () => { /*setDebuggerState(CPUState.Running);*/ };
-    const handlePause = () => { /*setDebuggerState(CPUState.Paused);*/ };
-    const handleStep = () => { /*setDebuggerState(CPUState.Stepping);*/ };
+    return ws.on('state', (data) => setDebuggerState(data));
+  }, [ws]);
 
-    return (
-        <div>
-            <WebSocketManager onMessage={handleNewMessage} onStateReceived={handleStateReceived} />
-            <Button onClick={handleStart} disabled={debuggerState?.cpu === CPUState.Running}>
-                Start
-            </Button>
-            <Button onClick={handlePause} disabled={debuggerState?.cpu !== CPUState.Running}>
-                Pause
-            </Button>
-            <Button onClick={handleStep} disabled={debuggerState?.cpu === CPUState.Running}>
-                Step
-            </Button>
-            <div>
-                <p>Debugger state: {debuggerState?.cpu}</p>
-            </div>
-        </div>
-    );
-};
+  const handleStart = () => {
+    /*setDebuggerState(CPUState.Running);*/
+  };
+  const handlePause = () => {
+    /*setDebuggerState(CPUState.Paused);*/
+    ws?.send('state', { cpu: CPUState.Paused });
+  };
+  const handleStep = () => {
+    /*setDebuggerState(CPUState.Stepping);*/
+  };
+
+  return (
+    <div>
+      <Button
+        onClick={handleStart}
+        disabled={debuggerState?.cpu === CPUState.Running}
+      >
+        Start
+      </Button>
+      <Button
+        onClick={handlePause}
+        disabled={debuggerState?.cpu !== CPUState.Running}
+      >
+        Pause
+      </Button>
+      <Button
+        onClick={handleStep}
+        disabled={debuggerState?.cpu === CPUState.Running}
+      >
+        Step
+      </Button>
+      <div>
+        <p>Debugger state: {debuggerState?.cpu}</p>
+      </div>
+    </div>
+  );
+}
 
 export default Debugger;
-

--- a/nestor-dbg/src/types.ts
+++ b/nestor-dbg/src/types.ts
@@ -1,0 +1,7 @@
+// Shared types between the server and the client
+
+export enum CPUState {
+  Running = 'running',
+  Paused = 'paused',
+  Stepping = 'stepping'
+}

--- a/nestor-dbg/src/ws/hook.ts
+++ b/nestor-dbg/src/ws/hook.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import WS from '.';
+
+let globalWSInstance: WS | null;
+
+export default function useWS(
+  wsUrl: string = 'ws://localhost:7777/ws'
+): [WS | null, boolean] {
+  const [ws, setWS] = useState<WS | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (globalWSInstance && globalWSInstance.settings.url !== wsUrl) {
+      globalWSInstance.close();
+      globalWSInstance = null;
+    }
+
+    if (!globalWSInstance) {
+      globalWSInstance = new WS({
+        url: wsUrl,
+        debug: process.env.NODE_ENV === 'development',
+        shouldReconnect: true
+      });
+    }
+
+    setWS(globalWSInstance);
+  }, [wsUrl]);
+
+  useEffect(() => {
+    if (!ws) return;
+
+    return ws.onConnectionChange(setReady);
+  }, [ws]);
+
+  return [ws, ready];
+}

--- a/nestor-dbg/src/ws/index.ts
+++ b/nestor-dbg/src/ws/index.ts
@@ -1,0 +1,157 @@
+// Dialogates with the debugger server via WebSocket
+
+import { WSMessage } from './types';
+
+const WS_URL = 'ws://localhost:7777/ws';
+const WS_RECONNECTION_TIMEOUT = 5000;
+const WS_RECONNECTION_MAX_RETRIES = 5;
+
+type WSEvents = {
+  connectionChange: ((open: boolean) => void)[]; // Connection status change
+  message: ((event: WSMessage['event'], data: WSMessage['data']) => void)[]; // Received message from server
+};
+
+export interface WSSettings {
+  url: string; // WebSocket URL
+  debug: boolean; // Enable debug logs
+  autoConnect: boolean; // Automatically connect on instantiation
+  shouldReconnect: boolean | (() => boolean); // Reconnect on close
+}
+
+const defaultSettings: WSSettings = {
+  url: WS_URL,
+  debug: false,
+  autoConnect: true,
+  shouldReconnect: true
+};
+
+class WS {
+  private retries = 0;
+  public settings: WSSettings;
+  private socket!: WebSocket | null;
+
+  private events: WSEvents = {
+    connectionChange: [],
+    message: []
+  };
+
+  constructor(settings: Partial<WSSettings> = {}) {
+    this.settings = { ...defaultSettings, ...settings };
+
+    if (this.settings.autoConnect) this.connect();
+    else this.socket = null;
+  }
+
+  private onSocketClose() {
+    this.log('Connection closed');
+
+    this.events.connectionChange.forEach((cb) => cb(false));
+
+    const shouldReconnect =
+      typeof this.settings.shouldReconnect === 'function'
+        ? this.settings.shouldReconnect()
+        : this.settings.shouldReconnect;
+
+    if (shouldReconnect) {
+      if (this.retries >= WS_RECONNECTION_MAX_RETRIES) {
+        this.log('Max retries reached, not reconnecting');
+        return;
+      }
+
+      this.log(`Reconnecting in ${WS_RECONNECTION_TIMEOUT / 1000}s...`);
+      setTimeout(() => this.connect(), WS_RECONNECTION_TIMEOUT);
+    }
+  }
+
+  // Logging
+  // TODO: replace with a proper logger or global logger with global debug flag
+  private log(...args: any[]) {
+    if (!this.settings.debug) return;
+
+    console.log('[WS]', ...args);
+  }
+
+  public connect() {
+    if (this.socket) {
+      this.log('Warning: already connected, closing existing connection');
+      this.socket.close();
+    }
+
+    this.log('Connecting to', this.settings.url);
+
+    this.socket = new WebSocket(this.settings.url);
+    this.socket.onopen = () => {
+      this.log('Connection established');
+      this.retries = 0;
+      this.events.connectionChange.forEach((cb) => cb(true));
+    };
+    this.socket.onmessage = (e: MessageEvent) => {
+      const { event, data } = JSON.parse(e.data) as WSMessage;
+      this.log(`Received from nestor: (${event})`, data);
+      this.events.message.forEach((cb) => cb(event, data));
+    };
+    this.socket.onclose = this.onSocketClose.bind(this);
+  }
+
+  public close() {
+    this.log('Gracefully closing');
+    this.socket?.close();
+  }
+
+  // Event listeners
+
+  private addEventListener(
+    event: keyof WSEvents,
+    callback: (...args: any[]) => void,
+    callImmediately = true
+  ) {
+    this.events[event].push(callback);
+
+    callImmediately && callback();
+
+    return () => {
+      // @ts-ignore
+      this.events[event] = this.events[event].filter((cb) => cb !== callback);
+    };
+  }
+
+  public onConnectionChange(
+    callback: (open: boolean) => void,
+    callImmediately = true
+  ) {
+    return this.addEventListener('connectionChange', callback, callImmediately);
+  }
+
+  public onMessage(
+    callback: (event: WSMessage['event'], data: WSMessage['data']) => void,
+    callImmediately = true
+  ) {
+    return this.addEventListener('message', callback, callImmediately);
+  }
+
+  /**
+   * Shortcut for listening to a specific event
+   *
+   * @example
+   * nestorWS.on('state', (data) => console.log('State:', data));
+   * is equivalent to: nestorWS.onMessage((e, data) => { if (e === 'state') console.log('State:', data); });
+   */
+  public on(
+    event: WSMessage['event'],
+    callback: (data: WSMessage['data']) => void
+  ) {
+    return this.addEventListener('message', (e, data) => {
+      if (e === event) callback(data);
+    });
+  }
+
+  // Send messages
+
+  public send(event: WSMessage['event'], data: WSMessage['data']) {
+    this.log(`Sending to nestor: (${event})`, data);
+
+    this.socket?.send(JSON.stringify({ event, data }));
+  }
+}
+
+export default WS;

--- a/nestor-dbg/src/ws/types.ts
+++ b/nestor-dbg/src/ws/types.ts
@@ -1,0 +1,12 @@
+import { CPUState } from '../types';
+
+// Types for the WebSocket communication
+export interface WSStateMessage {
+  event: 'state';
+  data: {
+    cpu: CPUState;
+  };
+}
+
+// All possible messages
+export type WSMessage = WSStateMessage /* | OtherMessage */;


### PR DESCRIPTION
I removed the react hook for connecting to the WebSocket with a custom class to have full control when receiving and exchanging data. 
I added a Prettier configuration file `/.prettierrc` to avoid different formatting styles (I use the 'prettier' extension for VSCode). I also added a /types.ts file where I thought we could put all the types we find in the core written in Go.

In the code, I inserted two hooks in `App.tsx` and `Debugger.tsx` to show that if you want to access the class, you can do so anywhere in the code. Perhaps a React Provider is more elegant, but in the long run, I think this approach makes it easier to use, and we can always change it later. Let me know what you think.



