### PR TITLE
Debugger: rework state handling

### DIFF
--- a/emu/debugger/driver.go
+++ b/emu/debugger/driver.go
@@ -42,7 +42,7 @@ type stateData struct {
 }
 
 type wsdriver struct {
-	dbg *reactDebugger
+	dbg *debugger
 	ws  *websocket.Conn
 
 	handlers map[string]wsHandlerFunc
@@ -50,7 +50,7 @@ type wsdriver struct {
 
 type wsHandlerFunc func(data []byte) (*WSResponse, error)
 
-func newWsDriver(dbg *reactDebugger, ws *websocket.Conn) *wsdriver {
+func newWsDriver(dbg *debugger, ws *websocket.Conn) *wsdriver {
 	drv := &wsdriver{
 		dbg:      dbg,
 		ws:       ws,

--- a/emu/debugger/listing.go
+++ b/emu/debugger/listing.go
@@ -31,7 +31,7 @@ type listing struct {
 	pos  layout.Position
 
 	cpu *hw.CPU
-	dbg *debugger
+	dbg *gioDebugger
 
 	cs      callStack
 	pc      uint16
@@ -42,7 +42,7 @@ type listing struct {
 	lblStyle material.LabelStyle
 }
 
-func newListing(dbg *debugger, theme *material.Theme, cpu *hw.CPU) listing {
+func newListing(dbg *gioDebugger, theme *material.Theme, cpu *hw.CPU) listing {
 	lblStyle := material.LabelStyle{
 		Color:          theme.Palette.Fg,
 		SelectionColor: ui.MulAlpha(theme.Palette.ContrastBg, 0x60),

--- a/emu/debugger/window.go
+++ b/emu/debugger/window.go
@@ -18,7 +18,7 @@ import (
 )
 
 type DebuggerWindow struct {
-	dbg *debugger
+	dbg *gioDebugger
 
 	theme *material.Theme
 
@@ -35,7 +35,7 @@ func NewDebuggerWindow(idbg hw.Debugger, cpu *hw.CPU, ppu *hw.PPU) *DebuggerWind
 	theme := material.NewTheme()
 	theme.Shaper = text.NewShaper(text.WithCollection(gofont.Collection()))
 
-	dbg := idbg.(*debugger)
+	dbg := idbg.(*gioDebugger)
 
 	return &DebuggerWindow{
 		dbg:      dbg,

--- a/emu/nes.go
+++ b/emu/nes.go
@@ -38,7 +38,7 @@ func (nes *NES) PowerUp(rom *ines.Rom, dbgAddr string) error {
 		nes.CPU.SetDebugger(nes.Debugger)
 	} else {
 		// nes.Debugger = debugger.NewDebugger(nes.CPU)
-		dbg, err := debugger.NewReactDebugger(nes.CPU, dbgAddr)
+		dbg, err := debugger.NewDebugger(nes.CPU, dbgAddr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix the problem of websocket disconnection by sending the correct debugger state in the initial message.
While I was at it, I rework and simplified a bit the handling of debugger state (in reception and emission).

I'm gonna merge and do a refactoring PR to remove the Gio debugger, and organizer the files for the react debugger a bit better.