### PR TITLE
hw: optimize execution tracer

### DIFF
--- a/hw/cpu_test.go
+++ b/hw/cpu_test.go
@@ -1,6 +1,8 @@
 package hw
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestPflag(t *testing.T) {
 	p := P(0x40)
@@ -53,5 +55,25 @@ func TestPString(t *testing.T) {
 	p = P(0b00000100)
 	if p.String() != "nvubdIzc" {
 		t.Errorf("got P = %s, want %s", p.String(), "nvubdIzc")
+	}
+}
+
+func BenchmarkDisasmOpString(b *testing.B) {
+	const want = `C000  4C F5 C5  JMP $C5F5`
+
+	op := DisasmOp{
+		Opcode: " JMP",
+		Oper:   "$C5F5",
+		Bytes:  []byte{0x4c, 0xf5, 0xc5},
+		PC:     0xC000,
+	}
+
+	opstr := ""
+	for range b.N {
+		opstr = op.String()
+	}
+
+	if opstr != want {
+		b.Fatalf("\ngot:  \"%s\"\nwant: \"%s\"\n", opstr, want)
 	}
 }


### PR DESCRIPTION
In DisasmOp.String(), reduce allocations from 5 to 1, and nanoseconds from 300 to 22