### PR TITLE
hw/mappers: fix MMC1 in 32KB prgmode

### DIFF
--- a/hw/mappers/axrom.go
+++ b/hw/mappers/axrom.go
@@ -28,7 +28,7 @@ func loadAxROM(b *base) (Mapper, error) {
 	b.init(axrom.WritePRGROM)
 
 	b.selectCHRROMPage8KB(0)
-	b.selectPRGPage32KB(0)
+	b.selectPRGPage32KB(0, 0)
 	return axrom, nil
 
 	// TODO: load and map PRG-RAM if present in cartridge.
@@ -51,7 +51,7 @@ func (m *axrom) WritePRGROM(addr uint16, val uint8) {
 	prev := m.prgbank
 	m.prgbank = uint32(val & 0x7)
 	if prev != m.prgbank {
-		m.selectPRGPage32KB(int(m.prgbank))
+		m.selectPRGPage32KB(0, int(m.prgbank))
 	}
 
 	prevntm := m.ntm
@@ -86,6 +86,6 @@ func (m *axrom) SetState(ms *snapshot.MapperState) {
 	m.busConflicts = s.BusConflicts
 
 	// Remap based on restored state
-	m.selectPRGPage32KB(int(m.prgbank))
+	m.selectPRGPage32KB(0, int(m.prgbank))
 	m.setNTMirroring(m.ntm)
 }

--- a/hw/mappers/base.go
+++ b/hw/mappers/base.go
@@ -168,6 +168,27 @@ func (b *base) numPRGROMBanks() int {
 
 // select what 32KB PRG ROM bank to use.
 func (b *base) selectPRGPage32KB(bank int) {
+	if len(b.rom.PRGROM) == 0 {
+		return
+	}
+	if bank < 0 {
+		if len(b.rom.PRGROM)%(32*KB) != 0 {
+			panic("PRGROM not multiple of 32KB")
+		}
+		bank += len(b.rom.PRGROM) / (32 * KB)
+	}
+
+	// wrap bank number if it is out of range
+	nbanks32KB := len(b.rom.PRGROM) / (32 * KB)
+	if nbanks32KB == 0 {
+		return
+	}
+	if bank < 0 {
+		bank += nbanks32KB
+	} else {
+		bank %= nbanks32KB
+	}
+
 	mirrorcopy(b.PRGROM[:], b.rom.PRGROM[32*KB*(bank):])
 }
 
@@ -190,9 +211,9 @@ func (b *base) selectPRGPage16KB(page uint32, bank int) {
 		return
 	}
 	if bank < 0 {
-		bank = nbanks + bank
+		bank += nbanks
 	} else {
-		bank = bank % nbanks
+		bank %= nbanks
 	}
 
 	offbus := 16 * KB * page

--- a/hw/mappers/base.go
+++ b/hw/mappers/base.go
@@ -167,29 +167,9 @@ func (b *base) numPRGROMBanks() int {
 }
 
 // select what 32KB PRG ROM bank to use.
-func (b *base) selectPRGPage32KB(bank int) {
-	if len(b.rom.PRGROM) == 0 {
-		return
-	}
-	if bank < 0 {
-		if len(b.rom.PRGROM)%(32*KB) != 0 {
-			panic("PRGROM not multiple of 32KB")
-		}
-		bank += len(b.rom.PRGROM) / (32 * KB)
-	}
-
-	// wrap bank number if it is out of range
-	nbanks32KB := len(b.rom.PRGROM) / (32 * KB)
-	if nbanks32KB == 0 {
-		return
-	}
-	if bank < 0 {
-		bank += nbanks32KB
-	} else {
-		bank %= nbanks32KB
-	}
-
-	mirrorcopy(b.PRGROM[:], b.rom.PRGROM[32*KB*(bank):])
+func (b *base) selectPRGPage32KB(page uint32, bank int) {
+	b.selectPRGPage16KB(page, bank*2)
+	b.selectPRGPage16KB(page+1, bank*2+1)
 }
 
 // select what 16KB PRG ROM bank to use into which PRG 16KB page.
@@ -206,14 +186,15 @@ func (b *base) selectPRGPage16KB(page uint32, bank int) {
 	}
 
 	// wrap bank number if it is out of range
-	nbanks := b.numPRGROMBanks()
-	if nbanks == 0 {
+	// Calculate number of 16KB banks (not mapper's PRGBankSize)
+	nbanks16KB := len(b.rom.PRGROM) / (16 * KB)
+	if nbanks16KB == 0 {
 		return
 	}
 	if bank < 0 {
-		bank += nbanks
+		bank += nbanks16KB
 	} else {
-		bank %= nbanks
+		bank %= nbanks16KB
 	}
 
 	offbus := 16 * KB * page

--- a/hw/mappers/bnrom.go
+++ b/hw/mappers/bnrom.go
@@ -32,7 +32,7 @@ func loadBNROM(b *base) (Mapper, error) {
 	b.setNTMirroring(b.rom.Mirroring())
 	// BNROM uses CHR-RAM (8KB), no bank switching
 	b.selectCHRROMPage8KB(0)
-	b.selectPRGPage32KB(0)
+	b.selectPRGPage32KB(0, 0)
 
 	return m34, nil
 }
@@ -56,7 +56,7 @@ func (m *mapper34) WritePRGROM(addr uint16, val uint8) {
 	prevprg := m.prgbank
 	m.prgbank = uint32(val & 0x3)
 	if prevprg != m.prgbank {
-		m.selectPRGPage32KB(int(m.prgbank))
+		m.selectPRGPage32KB(0, int(m.prgbank))
 	}
 }
 
@@ -76,5 +76,5 @@ func (m *mapper34) SetState(ms *snapshot.MapperState) {
 	m.base.setState(s.BaseState)
 	m.prgbank = s.PRGBank
 
-	m.selectPRGPage32KB(int(m.prgbank))
+	m.selectPRGPage32KB(0, int(m.prgbank))
 }

--- a/hw/mappers/cnrom.go
+++ b/hw/mappers/cnrom.go
@@ -29,7 +29,7 @@ func loadCNROM(b *base) (Mapper, error) {
 	// PPU mapping.
 	b.setNTMirroring(b.rom.Mirroring())
 	b.selectCHRROMPage8KB(0)
-	b.selectPRGPage32KB(0)
+	b.selectPRGPage32KB(0, 0)
 
 	return cnrom, nil
 

--- a/hw/mappers/gxrom.go
+++ b/hw/mappers/gxrom.go
@@ -24,7 +24,7 @@ func loadGxROM(b *base) (Mapper, error) {
 
 	b.setNTMirroring(b.rom.Mirroring())
 	b.selectCHRROMPage8KB(0)
-	b.selectPRGPage32KB(0)
+	b.selectPRGPage32KB(0, 0)
 	return gxrom, nil
 
 	// TODO: load and map PRG-RAM if present in cartridge.
@@ -47,7 +47,7 @@ func (m *gxrom) WritePRGROM(addr uint16, val uint8) {
 	prevprg := m.prgbank
 	m.prgbank = uint32((val >> 4) & 0x3)
 	if prevprg != m.prgbank {
-		m.selectPRGPage32KB(int(m.prgbank))
+		m.selectPRGPage32KB(0, int(m.prgbank))
 	}
 }
 
@@ -70,5 +70,5 @@ func (m *gxrom) SetState(ms *snapshot.MapperState) {
 
 	// Remap based on restored state
 	m.selectCHRROMPage8KB(int(m.chrbank))
-	m.selectPRGPage32KB(int(m.prgbank))
+	m.selectPRGPage32KB(0, int(m.prgbank))
 }

--- a/hw/mappers/mmc1.go
+++ b/hw/mappers/mmc1.go
@@ -255,13 +255,12 @@ func (m *mmc1) remap() {
 
 	switch m.prgmode {
 	case 0, 1:
-		// ignore low bit of bank number, then divide by 2 to get 32KB bank number
-		// Bank 0-1 -> 32KB bank 0, Bank 2-3 -> 32KB bank 1, etc.
-		// For SUROM (512KB), prgbankSelect is bit 4 (0x10), divide by 2 to get bank offset
-		calculatedBank := int(((m.prgbank & 0xFE) >> 1) | (prgbankSelect >> 1))
-		m.selectPRGPage32KB(calculatedBank)
+		// In 32KB mode, prgbank is a 16KB bank number (low bit ignored).
+		// Convert to 32KB bank number by dividing by 2.
+		bank16KB := int((m.prgbank & 0xFE) | (prgbankSelect))
+		m.selectPRGPage32KB(0, bank16KB/2)
 	case 2:
-		m.selectPRGPage16KB(0, int(0|prgbankSelect))
+		m.selectPRGPage16KB(0, int(prgbankSelect))
 		m.selectPRGPage16KB(1, int(m.prgbank|prgbankSelect))
 	case 3:
 		m.selectPRGPage16KB(0, int(m.prgbank|prgbankSelect))

--- a/hw/mappers/mmc1.go
+++ b/hw/mappers/mmc1.go
@@ -202,8 +202,8 @@ func (m *mmc1) remap() {
 	}
 	var prgbankSelect uint32
 	if len(m.rom.PRGROM) == 0x80000 {
-		// 512kb carts use bit 7 of $A000/$C000 to select page
-		// This is used for SUROM (Dragon Warrior 3/4, Dragon Quest 4)
+		// SUROM: 512kb carts use bit 7 of $A000/$C000 to select page.
+		// (Dragon Warrior 3/4, Dragon Quest 4)
 		prgbankSelect = extrareg & 0x10
 	}
 
@@ -255,8 +255,11 @@ func (m *mmc1) remap() {
 
 	switch m.prgmode {
 	case 0, 1:
-		// ignore low bit of bank number
-		m.selectPRGPage32KB(int((m.prgbank & 0xFE) | prgbankSelect))
+		// ignore low bit of bank number, then divide by 2 to get 32KB bank number
+		// Bank 0-1 -> 32KB bank 0, Bank 2-3 -> 32KB bank 1, etc.
+		// For SUROM (512KB), prgbankSelect is bit 4 (0x10), divide by 2 to get bank offset
+		calculatedBank := int(((m.prgbank & 0xFE) >> 1) | (prgbankSelect >> 1))
+		m.selectPRGPage32KB(calculatedBank)
 	case 2:
 		m.selectPRGPage16KB(0, int(0|prgbankSelect))
 		m.selectPRGPage16KB(1, int(m.prgbank|prgbankSelect))

--- a/hw/mappers/nrom.go
+++ b/hw/mappers/nrom.go
@@ -24,7 +24,7 @@ func loadNROM(b *base) (Mapper, error) {
 		b.selectPRGPage16KB(0, 0)
 		b.selectPRGPage16KB(1, 0) // mirror
 	case 32 * KB:
-		b.selectPRGPage32KB(0)
+		b.selectPRGPage32KB(0, 0)
 	default:
 		return nil, ErrUnsuppportedPRGROMSize(len(b.rom.PRGROM))
 	}


### PR DESCRIPTION
Fix MMC1 32KB PRG-ROM bank switching

`selectPRGPage32KB` was copying PRG-ROM data directly without proper bank wrapping, causing incorrect memory mapping in MMC1's 32KB mode. The fix reimplements it to call `selectPRGPage16KB` twice, reusing the existing bank-wrapping logic.
The bank wrapping in `selectPRGPage16KB` is also corrected to always count 16KB banks from the actual ROM size, rather than relying on the mapper's native bank size.
For MMC1, the 32KB mode now properly converts the 16KB-based prgbank value to a 32KB bank index.